### PR TITLE
Update requirements.txt: PySimpleGUI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pyperclip>=1.7.0
 animation>=0.0.6
 py-cpuinfo>=5.0.0
 dhooks>=1.1.0
-PySimpleGUI==4.3.2
+PySimpleGUI==4.11.0
 PySimpleGUIQt>=0.26.0
 PySide2>=5.13.0
 psutil>=5.6.3


### PR DESCRIPTION
PySimpleGUI version 4.3.2 was deleted, so the best version that worked without issues was 4.11.0. Should fix 2 currently open issues.