### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -84,3 +84,6 @@ Menu Theme can be changed by going to RTB > Themes > Change Theme, and setting c
 # **Disclaimer**
 
 I am not responsible for any bans you might/will receive using Raid ToolBox, Nor am I responsible for damages caused with Raid ToolBox, or other peoples actions with this program.
+
+
+[![Run on Repl.it](https://repl.it/badge/github/DeadBread76/Raid-Toolbox)](https://repl.it/github/DeadBread76/Raid-Toolbox)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).